### PR TITLE
feat: Create a new seatd service for DDE

### DIFF
--- a/data/systemd/CMakeLists.txt
+++ b/data/systemd/CMakeLists.txt
@@ -3,5 +3,3 @@ if (NOT DEFINED SYSTEMD_SYSTEM_UNIT_DIR)
     pkg_check_modules(Systemd REQUIRED systemd)
     pkg_get_variable(SYSTEMD_SYSTEM_UNIT_DIR systemd systemduserunitdir)
 endif()
-
-install(FILES override.conf DESTINATION ${SYSTEMD_SYSTEM_UNIT_DIR}/seatd.service.d/)

--- a/data/systemd/override.conf
+++ b/data/systemd/override.conf
@@ -1,4 +1,0 @@
-[Service]
-Environment=SEATD_VTBOUND=0
-ExecStart=
-ExecStart=seatd -u dde -g dde -l debug

--- a/services/CMakeLists.txt
+++ b/services/CMakeLists.txt
@@ -2,6 +2,9 @@ if(SYSTEMD_FOUND)
     configure_file(ddm.service.in ddm.service)
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/ddm.service" DESTINATION "${SYSTEMD_SYSTEM_UNIT_DIR}")
 
+    configure_file(seatd-dde.service.in seatd-dde.service)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/seatd-dde.service" DESTINATION "${SYSTEMD_SYSTEM_UNIT_DIR}")
+
     configure_file(ddm-sysuser.conf.in ddm-sysuser.conf)
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/ddm-sysuser.conf" DESTINATION "${SYSTEMD_SYSUSERS_DIR}" RENAME dde.conf)
 endif()

--- a/services/ddm.service.in
+++ b/services/ddm.service.in
@@ -7,8 +7,8 @@ PartOf=graphical.target
 StartLimitIntervalSec=30
 StartLimitBurst=2
 
-Requires=seatd.service
-Before=seatd.service
+Requires=seatd-dde.service
+Before=seatd-dde.service
 
 [Service]
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/ddm

--- a/services/seatd-dde.service.in
+++ b/services/seatd-dde.service.in
@@ -1,0 +1,62 @@
+[Unit]
+Description=Seat management daemon for DDE
+Documentation=man:seatd(1)
+Conflicts=seatd.service
+
+[Service]
+Type=simple
+Environment=SEATD_VTBOUND=0
+ExecStart=seatd -u dde -g dde
+Restart=always
+RestartSec=1
+
+# Filesystem lockdown
+ProtectHome=true
+ProtectSystem=strict
+ProtectKernelTunables=true
+ProtectControlGroups=true
+PrivateTmp=true
+ProtectProc=invisible
+ProcSubset=pid
+UMask=0077
+
+# Privilege escalation
+NoNewPrivileges=true
+RestrictSUIDSGID=true
+
+# Network
+PrivateNetwork=true
+IPAddressDeny=any
+
+# System call interfaces
+SystemCallFilter=@system-service
+SystemCallFilter=~@resources
+SystemCallErrorNumber=EPERM
+SystemCallArchitectures=native
+
+# Kernel
+ProtectKernelLogs=true
+ProtectKernelModules=true
+LockPersonality=true
+
+# Namespaces
+RestrictNamespaces=true
+
+# Service capabilities
+CapabilityBoundingSet=CAP_SYS_ADMIN CAP_CHOWN CAP_SYS_TTY_CONFIG CAP_DAC_OVERRIDE
+RestrictAddressFamilies=AF_UNIX
+RestrictRealtime=true
+MemoryDenyWriteExecute=true
+ProtectClock=true
+ProtectHostname=true
+
+# Devices
+DevicePolicy=strict
+DeviceAllow=char-/dev/console rw
+DeviceAllow=char-drm rw
+DeviceAllow=char-input rw
+DeviceAllow=char-tty rw
+DeviceAllow=/dev/null rw
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
1.  Introduce `seatd-dde.service` to avoid conflicts with the system's existing `seatd.service`. This allows Deepin Desktop Environment (DDE) to manage its seat without affecting other applications relying on `seatd`.
2.  Remove the override for the global `seatd.service`.  This prevents DDE's configuration from unintentionally altering the behavior of the system's seatd instance.
3.  Modify `ddm.service` to depend on `seatd-dde.service` instead of `seatd.service`. This ensures that DDE's display manager (ddm) utilizes the dedicated seatd service for DDE.
4.  The `seatd-dde.service` is configured to run as the `dde` user and group and sets `SEATD_VTBOUND=0`. It includes filesystem lockdown, privilege restriction, and network isolation settings for enhanced security.
5. The changes ensure that DDE's seat management operates independently, preventing potential interference with other system components.

feat: 为 DDE 创建新的 seatd 服务

1. 引入 `seatd-dde.service` 以避免与系统现有的 `seatd.service` 冲突。这 允许 Deepin 桌面环境 (DDE) 管理其会话，而不会影响依赖 `seatd` 的其他应用
程序。
2. 移除对全局 `seatd.service` 的覆盖。这可以防止 DDE 的配置意外更改系统 `seatd` 实例的行为。
3. 修改 `ddm.service` 以依赖 `seatd-dde.service` 而不是 `seatd.service`。这确保了 DDE 的显示管理器 (ddm) 使用专用于 DDE 的 seatd 服务。
4.  `seatd-dde.service` 配置为以 `dde` 用户和组运行，并设置 `SEATD_VTBOUND=0`。它包括文件系统锁定、权限限制和网络隔离设置，以增强安
全性。
5. 这些更改确保 DDE 的会话管理独立运行，防止与其他系统组件的潜在干扰。

## Summary by Sourcery

Isolate DDE’s seat management by introducing and installing a dedicated seatd-dde.service, updating ddm.service to use it, removing the global seatd override, and applying security hardening settings to the new unit.

New Features:
- Introduce a dedicated seatd-dde.service unit for DDE to manage seats independently

Enhancements:
- Modify ddm.service to depend on seatd-dde.service and remove the global seatd.service override to prevent interference
- Harden seatd-dde.service with SEATD_VTBOUND=0, user/group isolation, filesystem lockdown, privilege restrictions, and network isolation

Build:
- Add CMake installation rules for seatd-dde.service and remove installation of the global override.conf