### PR TITLE
chore(debian): update version to 0.1.11

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ddm (0.1.11) unstable; urgency=medium
+
+  * feat: Create a new seatd service for DDE
+
+ -- rewine <luhongxu@uniontech.com>  Thu, 31 Jul 2025 20:03:34 +0800
+
 ddm (0.1.10) unstable; urgency=medium
 
   * fix dde system user not in video group


### PR DESCRIPTION
Add support for the seatd service to improve device management integration with DDE. This change ensures proper handling of user sessions and device access control within the Deepin Desktop Environment.

## Summary by Sourcery

Update Debian packaging to version 0.1.11 and introduce seatd service support for improved device management in the Deepin Desktop Environment.

New Features:
- Add support for the seatd service to improve device management integration with DDE

Build:
- Bump Debian package version to 0.1.11

Documentation:
- Update Debian changelog with new version and feature entry