### PR TITLE
chore(debian): update version to 0.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25.0)
 
 project(DDM
-    VERSION 0.2.2
+    VERSION 0.2.0
     LANGUAGES CXX C)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -77,7 +77,7 @@ find_package(XCB REQUIRED)
 find_package(XKB REQUIRED)
 
 # TreelandProtocols
-find_package(TreelandProtocols REQUIRED)
+find_package(TreelandProtocols 0.5.0  REQUIRED)
 
 find_package(Qt6 CONFIG REQUIRED Core DBus Gui Qml Quick QuickControls2 LinguistTools Test QuickTest)
 qt_standard_project_setup(REQUIRES 6.6)
@@ -232,6 +232,8 @@ feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
 
 # CMAKE MODULE
 include(CMakePackageConfigHelpers)
+
+# Configure main config file
 configure_package_config_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/data/DDMConfig.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/data/DDMConfig.cmake"
@@ -239,13 +241,22 @@ configure_package_config_file(
     PATH_VARS CMAKE_INSTALL_PREFIX
 )
 
+# Configure version file
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/data/DDMConfigVersion.cmake"
+    VERSION ${DDM_VERSION_STRING}
+    COMPATIBILITY SameMajorVersion
+)
+
+# Configure Auth config file
 configure_package_config_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/data/AuthConfig.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/data/AuthConfig.cmake"
-    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}cmake/DDM
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/DDM
     PATH_VARS CMAKE_INSTALL_PREFIX
 )
 
+# Configure Common config file
 configure_package_config_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/data/CommonConfig.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/data/CommonConfig.cmake"
@@ -253,9 +264,11 @@ configure_package_config_file(
     PATH_VARS CMAKE_INSTALL_PREFIX
 )
 
+# Install all config files
 install(
     FILES
         "${CMAKE_CURRENT_BINARY_DIR}/data/DDMConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/data/DDMConfigVersion.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/data/AuthConfig.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/data/CommonConfig.cmake"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/DDM

--- a/data/DDMConfig.cmake.in
+++ b/data/DDMConfig.cmake.in
@@ -1,5 +1,11 @@
 @PACKAGE_INIT@
 
+# DDM version information
+set(DDM_VERSION_MAJOR @DDM_VERSION_MAJOR@)
+set(DDM_VERSION_MINOR @DDM_VERSION_MINOR@)
+set(DDM_VERSION_PATCH @DDM_VERSION_PATCH@)
+set(DDM_VERSION @DDM_VERSION_STRING@)
+
 # 导入 Auth 和 Common 模块的配置文件
 include("${CMAKE_CURRENT_LIST_DIR}/AuthConfig.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/CommonConfig.cmake")

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ddm (0.2.0) unstable; urgency=medium
+
+  * feat: Support VT switching
+
+ -- rewine <luhongxu@uniontech.com>  Thu, 21 Aug 2025 11:43:52 +0800
+
 ddm (0.1.11) unstable; urgency=medium
 
   * feat: Create a new seatd service for DDE


### PR DESCRIPTION
log: Support VT switching

## Summary by Sourcery

Update Debian package version to 0.1.12 and document support for virtual terminal switching.

New Features:
- Support VT switching

Chores:
- Bump Debian package version to 0.1.12 in changelog