### PR TITLE
fix: resolve missing source file issue for treeland-ddm-v1.c

### DIFF
--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -5,11 +5,22 @@ include_directories(
 
 pkg_search_module(WAYLAND REQUIRED IMPORTED_TARGET wayland-client)
 
-add_custom_target(treeland-ddm ALL
-    COMMAND
-    wayland-scanner client-header < ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-ddm-v1.xml > ${CMAKE_CURRENT_BINARY_DIR}/treeland-ddm-v1.h
-    COMMAND
-    wayland-scanner private-code < ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-ddm-v1.xml > ${CMAKE_CURRENT_BINARY_DIR}/treeland-ddm-v1.c
+# Generate treeland-ddm protocol files
+set(TREELAND_DDM_HEADER ${CMAKE_CURRENT_BINARY_DIR}/treeland-ddm-v1.h)
+set(TREELAND_DDM_SOURCE ${CMAKE_CURRENT_BINARY_DIR}/treeland-ddm-v1.c)
+
+add_custom_command(
+    OUTPUT ${TREELAND_DDM_HEADER}
+    COMMAND wayland-scanner client-header < ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-ddm-v1.xml > ${TREELAND_DDM_HEADER}
+    DEPENDS ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-ddm-v1.xml
+    COMMENT "Generating treeland-ddm-v1.h"
+)
+
+add_custom_command(
+    OUTPUT ${TREELAND_DDM_SOURCE}
+    COMMAND wayland-scanner private-code < ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-ddm-v1.xml > ${TREELAND_DDM_SOURCE}
+    DEPENDS ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-ddm-v1.xml
+    COMMENT "Generating treeland-ddm-v1.c"
 )
 
 configure_file(config.h.in config.h IMMEDIATE @ONLY)
@@ -31,7 +42,7 @@ set(DAEMON_SOURCES
     WaylandDisplayServer.h
     SingleWaylandDisplayServer.h
     SingleWaylandDisplayServer.cpp
-    treeland-ddm-v1.c
+    ${TREELAND_DDM_SOURCE}
 )
 
 qt_add_dbus_adaptor(DAEMON_SOURCES "${CMAKE_SOURCE_DIR}/data/interfaces/org.freedesktop.DisplayManager.xml"          "DisplayManager.h" DDM::DisplayManager)


### PR DESCRIPTION
1. Replace direct reference to "treeland-ddm-v1.c" in DAEMON_SOURCES with variable ${TREELAND_DDM_SOURCE} to ensure correct path resolution
2. Restructure protocol file generation using set() and add_custom_command() for better maintainability and clarity
3. Add DEPENDS and COMMENT fields to improve build system traceability and debugging
4. Ensure generated source files are correctly referenced during compilation

fix: 解决 treeland-ddm-v1.c 源文件找不到的问题

1. 将 DAEMON_SOURCES 中对 "treeland-ddm-v1.c" 的硬编码引用替换为变量 ${TREELAND_DDM_SOURCE}，确保路径正确解析
2. 使用 set() 和 add_custom_command() 重构协议文件生成流程，提高可维护性 和可读性
3. 添加 DEPENDS 和 COMMENT 字段以增强构建系统的可追踪性和调试能力
4. 确保在编译时正确引用生成的源文件

## Summary by Sourcery

Update daemon CMake build to properly generate and include the treeland-ddm-v1 protocol sources

Bug Fixes:
- Fix missing treeland-ddm-v1.c source file by referencing the generated source via variable

Enhancements:
- Introduce TREELAND_DDM_HEADER and TREELAND_DDM_SOURCE variables and split protocol file generation into separate add_custom_command invocations

Build:
- Add DEPENDS and COMMENT fields to protocol file generation commands
- Replace hardcoded treeland-ddm-v1.c in DAEMON_SOURCES with ${TREELAND_DDM_SOURCE}