### PR TITLE
fix: refine VT switch

### DIFF
--- a/src/daemon/TreelandConnector.h
+++ b/src/daemon/TreelandConnector.h
@@ -5,6 +5,7 @@
 #include <QSocketNotifier>
 
 struct wl_display;
+struct wl_callback;
 struct treeland_ddm;
 
 namespace DDM {
@@ -19,10 +20,11 @@ public:
 
     void switchToGreeter();
     void switchToUser(const QString username);
+    void ackVtSwitch(const int vtnr);
     void activateSession();
     void deactivateSession();
     void enableRender();
-    void disableRender();
+    struct wl_callback *disableRender();
 private:
     struct wl_display *m_display { nullptr };
     QSocketNotifier *m_notifier { nullptr };


### PR DESCRIPTION
1. Add callback for disableRender, make sure logics are execute in correct order;
2. Activate treeland session before acknowledge VT switch, to ensure all GUI elements are under a prepared state before next possible VT switch issued by keyboard;
3. Make event functions static;
4. Add comments, make code more readable;