### PR TITLE
fix: fix treeland get stuck in lockscreen after crash recovery

### DIFF
--- a/src/common/Messages.h
+++ b/src/common/Messages.h
@@ -50,6 +50,7 @@ namespace DDM {
         InformationMessage,
         UserActivateMessage,
         SwitchToGreeter,
+        UserLoggedIn,
     };
 
     enum Capability {

--- a/src/daemon/Display.h
+++ b/src/daemon/Display.h
@@ -75,6 +75,7 @@ namespace DDM {
         bool start();
         void stop();
 
+        void connected(QLocalSocket *socket);
         void login(QLocalSocket *socket,
                    const QString &user, const QString &password,
                    const Session &session);


### PR DESCRIPTION
Treeland will get stuck in lockscreen after a crash recovery, which is caused by unintended login request for already logined user. This commit adds a new DaemonMessages type, and convey logined user to treeland after socket connected, to avoid this problem.

## Summary by Sourcery

Send active user session data to Treeland upon socket reconnection to avoid redundant login prompts and lockscreen hangs after crash recovery

New Features:
- Add DaemonMessages::UserLogined enum to signal active user sessions

Bug Fixes:
- Prevent Treeland from getting stuck at the lockscreen after crash recovery by avoiding unintended login requests for already authenticated users

Enhancements:
- Connect to SocketServer::connected signal and implement Display::connected to send current logged-in users via SocketWriter