### PR TITLE
feat: Starting X11 dde-session using ddm

### DIFF
--- a/data/scripts/Xsetup
+++ b/data/scripts/Xsetup
@@ -1,3 +1,6 @@
 #!/bin/sh
 # Xsetup - run as root before the login dialog appears
 
+# Allow all client connect to the Xorg server. Since our X server is started as
+# root, but sessions are started as user.
+xhost +

--- a/src/auth/Auth.h
+++ b/src/auth/Auth.h
@@ -23,6 +23,7 @@
 
 #include "AuthRequest.h"
 #include "AuthPrompt.h"
+#include "Session.h"
 
 #include <QtCore/QObject>
 #include <QtCore/QProcessEnvironment>
@@ -97,12 +98,15 @@ namespace DDM {
         bool isGreeter() const;
         bool verbose() const;
         bool identifyOnly() const;
+        bool isSingleMode() const;
         const QByteArray &cookie() const;
         const QString &user() const;
         const QString &session() const;
         const QString &password() const;
         AuthRequest *request();
         QString sessionId() const;
+        Session::Type sessionType() const;
+        QString sessionFileName() const;
         int tty() const;
 
         void setTTY(int tty);
@@ -146,6 +150,8 @@ namespace DDM {
         void setVerbose(bool on = true);
 
         void setIdentifyOnly(bool on = false);
+
+        void setSkipAuth(bool on = true);
         /**
         * Sets the user which will then authenticate
         * @param user username
@@ -179,7 +185,11 @@ namespace DDM {
          */
         void setSingleMode(bool on = true);
 
-        void setSessionId(const QString& sessionId);
+        void setSessionId(const QString &sessionId);
+
+        void setSessionType(const Session::Type type);
+
+        void setSessionFileName(const QString &fileName);
 
     public Q_SLOTS:
         /**

--- a/src/daemon/Greeter.h
+++ b/src/daemon/Greeter.h
@@ -42,6 +42,8 @@ namespace DDM {
         void setSocket(const QString &socket);
         void setTheme(const QString &theme);
         void setSingleMode(bool on = true);
+        void setUser(const QString &user);
+        void setSkipAuth(bool on = true);
         void setUserActivated(bool active);
 
         QString displayServerCommand() const;
@@ -67,6 +69,7 @@ namespace DDM {
         void ttyFailed();
         void failed();
         void displayServerFailed();
+        void succeed();
         void greeterStarted();
 
     private:
@@ -75,6 +78,8 @@ namespace DDM {
         bool m_userActivated { false };
         int m_currentRetry { 0 };
         int m_maxRetry{ 3 };
+        QString m_user = QStringLiteral("dde");
+        bool m_skipAuth { false };
 
         Display * const m_display { nullptr };
         QString m_socket;

--- a/src/helper/HelperApp.cpp
+++ b/src/helper/HelperApp.cpp
@@ -123,6 +123,10 @@ namespace DDM {
             m_backend->setIdentifyOnly(true);
         }
 
+        if ((pos = args.indexOf(QStringLiteral("--skip-auth"))) >= 0) {
+            m_skipAuth = true;
+        }
+
         if (server.isEmpty() || m_id <= 0) {
             qCritical() << "This application is not supposed to be executed manually";
             exit(Auth::HELPER_OTHER_ERROR);
@@ -163,7 +167,7 @@ namespace DDM {
         }
 
         Q_ASSERT(getuid() == 0);
-        if (!m_backend->authenticate()) {
+        if (!m_skipAuth && !m_backend->authenticate()) {
             authenticated(QString());
 
             // write failed login to btmp

--- a/src/helper/HelperApp.h
+++ b/src/helper/HelperApp.h
@@ -67,6 +67,7 @@ namespace DDM {
         QString m_user { };
         // TODO: get rid of this in a nice clean way along the way with moving to user session X server
         QByteArray m_cookie { };
+        bool m_skipAuth = false;
 
         /*!
          \brief Write utmp/wtmp/btmp records when a user logs in

--- a/src/helper/UserSession.cpp
+++ b/src/helper/UserSession.cpp
@@ -122,14 +122,9 @@ namespace DDM {
                 }
 
                 qInfo() << "Starting X11 session:" << m_displayServerCmd << command;
-                if (m_displayServerCmd.isEmpty()) {
-                    auto args = QProcess::splitCommand(command);
-                    setProgram(args.takeFirst());
-                    setArguments(args);
-                } else {
-                    setProgram(QStringLiteral(LIBEXEC_INSTALL_DIR "/ddm-helper-start-x11user"));
-                    setArguments({m_displayServerCmd, command});
-                }
+                auto args = QProcess::splitCommand(m_displayServerCmd);
+                setProgram(args.takeFirst());
+                setArguments(args);
                 QProcess::start();
 
             } else if (env.value(QStringLiteral("XDG_SESSION_TYPE")) == QLatin1String("wayland")) {
@@ -238,7 +233,7 @@ namespace DDM {
 
             // take control of the tty
             if (takeControl) {
-                if (ioctl(STDIN_FILENO, TIOCSCTTY, 0) < 0) {
+                if (ioctl(STDIN_FILENO, TIOCSCTTY, 1) < 0) {
                     const auto error = strerror(errno);
                     qCritical().nospace() << "Failed to take control of " << ttyString << " (" << QFileInfo(ttyString).owner() << "): " << error;
                     _exit(Auth::HELPER_TTY_ERROR);


### PR DESCRIPTION
This commit modifies X11DisplayServerType to start X11 with ddm. It use treeland as greeter to handle user login. Once user logged in, it kills the wayland compositor and start the X11 server.

## Summary by Sourcery

Implement X11 session startup via ddm by launching a temporary Wayland greeter for authentication before tearing it down and starting the Xorg server, with new skip-auth support and simplified session launch logic.

New Features:
- Support X11DisplayServerType: boot a SingleWaylandDisplayServer as greeter, then switch to XorgDisplayServer after login
- Add skip-auth mode in Auth and Greeter to bypass authentication for X11 sessions

Bug Fixes:
- Fix ioctl TIOCSCTTY flag to correctly take control of the terminal

Enhancements:
- Unify UserSession command handling to directly use the configured X11 session command instead of a wrapper helper
- Expose setUser and setSkipAuth methods in Greeter for dynamic login configuration