### PR TITLE
fix: Fix nix build failure & incorrect versioning

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,47 +1,8 @@
 {
   "nodes": {
-    "dde-nixos": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709021750,
-        "narHash": "sha256-WpK0Qj2NMxsm6t1ZMM4VdHtF/DTHTOAjk7qJozm4PNQ=",
-        "owner": "linuxdeepin",
-        "repo": "dde-nixos",
-        "rev": "40f10d06a2009049060ce78010c0c5c16b8a60bd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "linuxdeepin",
-        "repo": "dde-nixos",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1710146030,
@@ -88,42 +49,12 @@
         "type": "github"
       }
     },
-    "qwlroots": {
-      "inputs": {
-        "flake-utils": [
-          "waylib",
-          "flake-utils"
-        ],
-        "nix-filter": [
-          "waylib",
-          "nix-filter"
-        ],
-        "nixpkgs": [
-          "waylib",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1704874869,
-        "narHash": "sha256-NAUmwMOzH2XGn2iFZVbj4o91nP3/Fp2f3BnUEzVetUs=",
-        "owner": "vioken",
-        "repo": "qwlroots",
-        "rev": "dd9c126499ed474eb7a7534c945798c4b07ef4b7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "vioken",
-        "repo": "qwlroots",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "dde-nixos": "dde-nixos",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs",
-        "waylib": "waylib"
+        "treeland-protocols": "treeland-protocols"
       }
     },
     "systems": {
@@ -141,22 +72,7 @@
         "type": "github"
       }
     },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "waylib": {
+    "treeland-protocols": {
       "inputs": {
         "flake-utils": [
           "flake-utils"
@@ -166,20 +82,19 @@
         ],
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "qwlroots": "qwlroots"
+        ]
       },
       "locked": {
-        "lastModified": 1715060968,
-        "narHash": "sha256-k5OQsOs7/WB/G2hxi+9cm7FbSJ+w8m1bQZBGkLezD+c=",
-        "owner": "vioken",
-        "repo": "waylib",
-        "rev": "b3fe4e2716d680ed8a394258d0ba850feb11ad07",
+        "lastModified": 1756440142,
+        "narHash": "sha256-wO89wmKLMnHvjB19vPMGetutdPlji32ZHSnTll3+eFY=",
+        "owner": "linuxdeepin",
+        "repo": "treeland-protocols",
+        "rev": "d8d6294b133aa7b02229e4311085773f623fe46f",
         "type": "github"
       },
       "original": {
-        "owner": "vioken",
-        "repo": "waylib",
+        "owner": "linuxdeepin",
+        "repo": "treeland-protocols",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -5,9 +5,17 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     nix-filter.url = "github:numtide/nix-filter";
+    treeland-protocols = {
+      url = "github:linuxdeepin/treeland-protocols";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        nix-filter.follows = "nix-filter";
+        flake-utils.follows = "flake-utils";
+      };
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, nix-filter }@input:
+  outputs = { self, nixpkgs, flake-utils, nix-filter, treeland-protocols }@input:
     flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" "riscv64-linux" ]
       (system:
         let
@@ -15,6 +23,7 @@
 
           ddm = pkgs.qt6Packages.callPackage ./nix {
             nix-filter = nix-filter.lib;
+            treeland-protocols = treeland-protocols.packages.${system}.default;
           };
         in
         {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -12,11 +12,12 @@
 , pam
 , libxcrypt
 , treeland-protocols
+, wayland
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ddm";
-  version = "0.2.2";
+  version = "0.2.0";
 
   src = nix-filter.filter {
     root = ./..;
@@ -45,6 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     qttools
     wrapQtAppsHook
+    wayland-scanner
   ];
 
   buildInputs = [
@@ -53,6 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     pam
     libxcrypt
     treeland-protocols
+    wayland
   ];
 
    cmakeFlags = [


### PR DESCRIPTION
Fixed a list of things below (for building on Nix):
- required input `treeland-protocols` in `nix/default.nix` was not passed when calling the ddm package.
- dependency `wayland` was not declared.
- `wayland-scanner` is used in building process, but was never declared in `nativeBuildInputs`.
- `flake.lock` depending on multiple `nixpkgs`, `flake-utils` and `nix-filters` instances.

## Summary by Sourcery

Fix Nix build failures and versioning by declaring missing package inputs, correcting the ddm version, and consolidating flake dependencies

Bug Fixes:
- Add treeland-protocols input to flake.nix and pass it to the ddm package
- Declare wayland and wayland-scanner in default.nix to satisfy build requirements
- Correct ddm version from 0.2.2 to 0.2.0

Build:
- Unify flake.lock to use single instances of nixpkgs, flake-utils, and nix-filter