### PR TITLE
fix(auth): prevent Qt atexit deadlock in PAM fork children

### DIFF
--- a/src/daemon/Auth.cpp
+++ b/src/daemon/Auth.cpp
@@ -13,6 +13,7 @@
 
 #include <pwd.h>
 #include <security/pam_appl.h>
+#include <pthread.h>
 #include <signal.h>
 #include <unistd.h>
 #include <utmp.h>
@@ -265,6 +266,19 @@ namespace DDM {
                 env.insert(QStringLiteral("USER"), QString::fromLocal8Bit(pw->pw_name));
                 env.insert(QStringLiteral("LOGNAME"), QString::fromLocal8Bit(pw->pw_name));
             }
+
+            // PAM modules (e.g. pam_gnome_keyring) may fork() internally and
+            // call exit() instead of _exit() in the fork child, which triggers
+            // Qt's atexit cleanup (including libQt6DBus joining its dispatcher
+            // thread). After fork(), that thread doesn't exist, so the join
+            // blocks forever on a futex/semaphore.
+            //
+            // Register a pthread_atfork child handler here so that any
+            // grandchild processes spawned by PAM will have an atexit handler
+            // that runs _exit() first (LIFO), bypassing Qt's broken cleanup.
+            pthread_atfork(nullptr, nullptr, []() {
+                atexit([]() { _exit(0); });
+            });
 
             // Open session
             auto sessionEnv = openSessionInternal(env);


### PR DESCRIPTION
PAM modules (notably pam_gnome_keyring) may fork() internally and call exit() instead of _exit() in the fork child, e.g. when starting a daemon or communicating with an existing one. Since the DDM session leader inherits Qt's atexit handlers, exit() triggers libQt6DBus cleanup which tries to join its dispatcher thread. After fork(), only the calling thread survives, so the join blocks forever on a futex.

Fix this by registering a pthread_atfork child handler in the session leader, right before pam_open_session(). The handler pushes an atexit entry that calls _exit(0); since atexit handlers run in LIFO order, this runs first and terminates the grandchild without executing Qt's broken post-fork cleanup.

This fixes the immediate stuck after clicking login on Arch Linux.

## Summary by Sourcery

Bug Fixes:
- Prevent login from hanging when PAM modules fork and call exit() in the child by ensuring those processes terminate via _exit() instead of running Qt's atexit cleanup.