### PR TITLE
fix: register ddm as a display manager via debconf

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,9 +19,8 @@ Rules-Requires-Root: no
 
 Package: ddm
 Section: libdevel
-#Provides: x-display-manager
+Provides: x-display-manager
 Architecture: any
-Multi-Arch: same
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          seatd,

--- a/debian/ddm.config
+++ b/debian/ddm.config
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Debian ddm package configuration script
+# based on lightdm script (based on xdm script)
+# Copyright 2001 Branden Robinson.
+# Licensed under the GNU General Public License, version 2.
+
+set -e
+
+# source debconf library
+. /usr/share/debconf/confmodule
+
+# set default display manager
+DEFAULT_DISPLAY_MANAGER_FILE=/etc/X11/default-display-manager
+
+THIS_PACKAGE=ddm
+
+OWNERS=
+if db_metaget shared/default-x-display-manager owners; then
+  OWNERS="$RET"
+fi
+
+CHOICES=
+if db_metaget shared/default-x-display-manager choices; then
+  CHOICES="$RET"
+fi
+
+if [ "$OWNERS" != "$CHOICES" ]; then
+  # Strip architecture qualifiers (e.g. "ddm:amd64" -> "ddm") so that the
+  # displayed choices and the value stored in default-display-manager file
+  # (plain package name) stay in sync.
+  OWNERS_CLEAN=$(echo "$OWNERS" | sed 's/:[[:alnum:]_-]*//g')
+  db_subst shared/default-x-display-manager choices "$OWNERS_CLEAN" || :
+  db_fset shared/default-x-display-manager seen false || :
+fi
+
+# debconf is not a registry; use the current contents of the default display
+# manager file to pre-answer the question if possible
+if [ -e "$DEFAULT_DISPLAY_MANAGER_FILE" ]; then
+  CURRENT_DEFAULT=$(grep -v '^[[:space:]]*#' "$DEFAULT_DISPLAY_MANAGER_FILE" | head -n 1)
+  if [ -n "$CURRENT_DEFAULT" ]; then
+    CURRENT_DEFAULT=$(basename "$CURRENT_DEFAULT")
+    db_set shared/default-x-display-manager "$CURRENT_DEFAULT"
+  fi
+else
+  CURRENT_DEFAULT=
+  if db_get shared/default-x-display-manager; then
+    CURRENT_DEFAULT="$RET"
+  fi
+fi
+
+db_input high shared/default-x-display-manager || :
+db_go || :
+
+# using this display manager?
+NEW_DEFAULT=
+if db_get shared/default-x-display-manager; then
+  NEW_DEFAULT="$RET"
+fi
+
+# move the default display manager file if we are going to change it
+if [ -n "$NEW_DEFAULT" ]; then
+  if [ "$NEW_DEFAULT" != "$CURRENT_DEFAULT" ]; then
+    if [ -e "$DEFAULT_DISPLAY_MANAGER_FILE" ]; then
+      mv "$DEFAULT_DISPLAY_MANAGER_FILE" \
+         "${DEFAULT_DISPLAY_MANAGER_FILE}.dpkg-tmp"
+    fi
+  fi
+fi

--- a/debian/ddm.postrm
+++ b/debian/ddm.postrm
@@ -34,6 +34,22 @@ case "$1" in
         fi
 
         ;;
+    remove)
+        # Update the display-manager.service symlink to point to the newly
+        # chosen display manager (written by prerm into DEFAULT_DISPLAY_MANAGER_FILE)
+        if [ -e "$DEFAULT_DISPLAY_MANAGER_FILE" ] && [ -d /etc/systemd/system/ ]; then
+            DM=$(basename "$(cat "$DEFAULT_DISPLAY_MANAGER_FILE")")
+            SERVICE=/lib/systemd/system/$DM.service
+            if [ -h "$DEFAULT_SERVICE" ] && [ "$(readlink "$DEFAULT_SERVICE")" = /dev/null ]; then
+                echo "Display manager service is masked" >&2
+            elif [ -e "$SERVICE" ]; then
+                ln -sf "$SERVICE" "$DEFAULT_SERVICE"
+            fi
+        elif [ -h "$DEFAULT_SERVICE" ] && [ ! -e "$DEFAULT_SERVICE" ]; then
+            # Dangling symlink, no other display-manager installed
+            rm -f "$DEFAULT_SERVICE"
+        fi
+        ;;
     abort-install|abort-upgrade)
         # roll back displacement of default display manager file
         if [ -e "$DEFAULT_DISPLAY_MANAGER_FILE.dpkg-tmp" ]; then

--- a/debian/ddm.prerm
+++ b/debian/ddm.prerm
@@ -20,12 +20,16 @@ if [ "$1" = "remove" ] || [ "$1" = "deconfigure" ]; then
     # does the question still exist?
     if db_get shared/default-x-display-manager; then
       db_metaget shared/default-x-display-manager owners
-      db_subst shared/default-x-display-manager choices "$RET"
+      # Strip architecture qualifiers (e.g. "lightdm:amd64" -> "lightdm")
+      OWNERS_CLEAN=$(echo "$RET" | sed 's/:[[:alnum:]_-]*//g')
+      db_subst shared/default-x-display-manager choices "$OWNERS_CLEAN"
       db_get shared/default-x-display-manager
+      # Strip architecture qualifier from current value too
+      CURRENT_DM=$(echo "$RET" | sed 's/:[[:alnum:]_-]*//')
       # are we removing the currently selected display manager?
-      if [ "$THIS_PACKAGE" = "$RET" ]; then
+      if [ "$THIS_PACKAGE" = "$CURRENT_DM" ]; then
         if [ -e "$DEFAULT_DISPLAY_MANAGER_FILE" ]; then
-	  db_get "$RET"/daemon_name
+	  db_get "$THIS_PACKAGE"/daemon_name
 	  if [ "$(cat $DEFAULT_DISPLAY_MANAGER_FILE)" = "$RET" ]; then
 	    rm "$DEFAULT_DISPLAY_MANAGER_FILE"
 	  fi
@@ -38,9 +42,14 @@ if [ "$1" = "remove" ] || [ "$1" = "deconfigure" ]; then
         # to the new default display manager
         if [ ! -e $DEFAULT_DISPLAY_MANAGER_FILE ]; then
           db_get shared/default-x-display-manager
-          echo "Please be sure to run \"dpkg-reconfigure $RET\"."
-          db_get "$RET"/daemon_name
-          echo "$RET" > "$DEFAULT_DISPLAY_MANAGER_FILE"
+          # Strip any architecture qualifier from user's selection
+          NEW_DM=$(echo "$RET" | sed 's/:[[:alnum:]_-]*//')
+          echo "Please be sure to run \"dpkg-reconfigure $NEW_DM\"."
+          if db_get "$NEW_DM"/daemon_name && [ -n "$RET" ]; then
+            echo "$RET" > "$DEFAULT_DISPLAY_MANAGER_FILE"
+          else
+            echo "/usr/bin/$NEW_DM" > "$DEFAULT_DISPLAY_MANAGER_FILE"
+          fi
         fi
       fi
     fi

--- a/debian/ddm.templates
+++ b/debian/ddm.templates
@@ -1,0 +1,20 @@
+Template: ddm/daemon_name
+Type: string
+Default: /usr/bin/ddm
+Description: for internal use only
+
+Template: shared/default-x-display-manager
+Type: select
+Choices: ${choices}
+Description: Default display manager:
+ A display manager is a program that provides graphical login capabilities for
+ the X Window System and Wayland compositors.
+ .
+ Only one display manager can manage a given X server, but multiple display
+ manager packages are installed. Please select which display manager should
+ run by default.
+ .
+ Multiple display managers can run simultaneously if they are configured to
+ manage different servers; to achieve this, configure the display managers
+ accordingly, edit each of their init scripts in /etc/init.d, and disable the
+ check for a default display manager.


### PR DESCRIPTION
Reinstalling ddm would reset the default display manager to lightdm because ddm did not participate in the Debian display manager selection mechanism. Add missing debconf templates and config script (modeled after lightdm) to properly register ddm, and uncomment Provides: x-display-manager in debian/control.