### PR TITLE
fix: add error handling when sourcing profile scripts

### DIFF
--- a/data/scripts/Xsession
+++ b/data/scripts/Xsession
@@ -26,22 +26,22 @@ case $SHELL in
     rm -f $xsess_tmp
     ;;
   */fish)
-    [ -f /etc/profile ] && . /etc/profile
-    [ -f $HOME/.profile ] && . $HOME/.profile
+    [ -f /etc/profile ] && { . /etc/profile 2>/dev/null || echo "Warning: Failed to source /etc/profile" >&2; }
+    [ -f $HOME/.profile ] && { . $HOME/.profile 2>/dev/null || echo "Warning: Failed to source $HOME/.profile" >&2; }
     xsess_tmp=`mktemp /tmp/xsess-env-XXXXXX`
     $SHELL --login -c "/bin/sh -c 'export -p' > $xsess_tmp"
     . $xsess_tmp
     rm -f $xsess_tmp
     ;;
   *) # Plain sh, ksh, and anything we do not know.
-    [ -f /etc/profile ] && . /etc/profile
-    [ -f $HOME/.profile ] && . $HOME/.profile
+    [ -f /etc/profile ] && { . /etc/profile 2>/dev/null || echo "Warning: Failed to source /etc/profile" >&2; }
+    [ -f $HOME/.profile ] && { . $HOME/.profile 2>/dev/null || echo "Warning: Failed to source $HOME/.profile" >&2; }
     ;;
 esac
 
-[ -f /etc/xprofile ] && . /etc/xprofile
-[ -f /usr/local/etc/xprofile ] && . /usr/local/etc/xprofile
-[ -f $HOME/.xprofile ] && . $HOME/.xprofile
+[ -f /etc/xprofile ] && { . /etc/xprofile 2>/dev/null || echo "Warning: Failed to source /etc/xprofile" >&2; }
+[ -f /usr/local/etc/xprofile ] && { . /usr/local/etc/xprofile 2>/dev/null || echo "Warning: Failed to source /usr/local/etc/xprofile" >&2; }
+[ -f $HOME/.xprofile ] && { . $HOME/.xprofile 2>/dev/null || echo "Warning: Failed to source $HOME/.xprofile" >&2; }
 
 # run all system xinitrc shell scripts.
 if [ -d /etc/X11/xinit/xinitrc.d ]; then
@@ -81,10 +81,10 @@ fi
 [ -f $HOME/.Xresources ] && xrdb -merge $HOME/.Xresources
 
 if [ -f "$USERXSESSIONRC" ]; then
-  . "$USERXSESSIONRC"
+  { . "$USERXSESSIONRC" 2>/dev/null || echo "Warning: Failed to source $USERXSESSIONRC" >&2; }
 fi
 if [ -f "$USERXSESSION" ]; then
-  . "$USERXSESSION"
+  { . "$USERXSESSION" 2>/dev/null || echo "Warning: Failed to source $USERXSESSION" >&2; }
 fi
 
 if [ -z "$*" ]; then

--- a/data/scripts/wayland-session
+++ b/data/scripts/wayland-session
@@ -30,16 +30,16 @@ case $SHELL in
     rm -f $wlsess_tmp
     ;;
   */fish)
-    [ -f /etc/profile ] && . /etc/profile
-    [ -f $HOME/.profile ] && . $HOME/.profile
+    [ -f /etc/profile ] && { . /etc/profile 2>/dev/null || echo "Warning: Failed to source /etc/profile" >&2; }
+    [ -f $HOME/.profile ] && { . $HOME/.profile 2>/dev/null || echo "Warning: Failed to source $HOME/.profile" >&2; }
     xsess_tmp=`mktemp /tmp/xsess-env-XXXXXX`
     $SHELL --login -c "/bin/sh -c 'export -p' > $xsess_tmp"
     . $xsess_tmp
     rm -f $xsess_tmp
     ;;
   *) # Plain sh, ksh, and anything we do not know.
-    [ -f /etc/profile ] && . /etc/profile
-    [ -f $HOME/.profile ] && . $HOME/.profile
+    [ -f /etc/profile ] && { . /etc/profile 2>/dev/null || echo "Warning: Failed to source /etc/profile" >&2; }
+    [ -f $HOME/.profile ] && { . $HOME/.profile 2>/dev/null || echo "Warning: Failed to source $HOME/.profile" >&2; }
     ;;
 esac
 


### PR DESCRIPTION
Suppress stderr and emit a warning to stderr when sourcing /etc/profile, /etc/xprofile, /usr/local/etc/xprofile, $HOME/.profile, $HOME/.xprofile, $HOME/.xsessionrc, or $HOME/.xsession fails, preventing broken user configs from crashing the session startup.

## Summary by Sourcery

Handle failures when sourcing user and system profile scripts during X session startup to avoid crashing the session.

Bug Fixes:
- Suppress stderr and emit explicit warnings when sourcing /etc/profile and user profile files fails in Xsession.
- Prevent failures in sourcing X-specific profile and session rc scripts from aborting X session startup.