### PR TITLE
fix(vt): avoid repeated VT handlers and restore session state

### DIFF
--- a/src/daemon/TreelandConnector.cpp
+++ b/src/daemon/TreelandConnector.cpp
@@ -88,6 +88,7 @@ static void renderDisabled([[maybe_unused]] void *data, struct wl_callback *call
         VirtualTerminal::handleVtSwitches(activeVtFd);
         close(activeVtFd);
 
+        conn->activateSession();
         conn->enableRender();
         conn->switchToUser(user.isEmpty() ? "dde" : user);
     } else {

--- a/src/daemon/VirtualTerminal.cpp
+++ b/src/daemon/VirtualTerminal.cpp
@@ -117,7 +117,8 @@ namespace DDM {
 
             daemonApp->signalHandler()->addCustomSignal(RELEASE_DISPLAY_SIGNAL);
             daemonApp->signalHandler()->addCustomSignal(ACQUIRE_DISPLAY_SIGNAL);
-            QObject::connect(daemonApp->signalHandler(), &SignalHandler::customSignalReceived, onVtSignal);
+            QObject::connect(daemonApp->signalHandler(), &SignalHandler::customSignalReceived,
+                             daemonApp->signalHandler(), onVtSignal, Qt::UniqueConnection);
 
             return ok;
         }


### PR DESCRIPTION
Ensure VT signal handling is connected only once per process.

确保VT信号处理在进程内只连接一次。

Restore Treeland session active state before switching users.

在切换到Treeland管理用户前恢复会话激活状态。

Log: 修复VT切换重复处理与会话状态恢复
Influence: 降低切换到Treeland用户后被拉回或状态不一致的风险。

## Summary by Sourcery

Ensure VT signal handling is only connected once per process and restore session activation before switching to the Treeland-managed user.

Bug Fixes:
- Prevent duplicate VT custom signal handlers from being connected, avoiding repeated VT handling.
- Restore the Treeland session to an active state before switching users to avoid being pulled back or ending in an inconsistent state.