### PR TITLE
fix: vt user lookup to prefer real user sessions over greeter entries

### DIFF
--- a/src/daemon/DisplayManager.cpp
+++ b/src/daemon/DisplayManager.cpp
@@ -180,10 +180,31 @@ namespace DDM {
     }
 
     const QString DisplayManager::findUserByVt(int vtnr) {
-        for (auto session : m_sessions) {
-            if (vtnr == session->VTNr())
-                return session->User();
+        QString greeterUser = QStringLiteral("dde");
+
+        for (const auto& session : m_sessions) {
+            if (!session) {
+                continue;
+            }
+
+            if (vtnr == session->VTNr()) {
+                if (session->User() != greeterUser) {
+                    qDebug() << "[DisplayManager] findUserByVt selected user session vtnr="
+                             << vtnr << " user=" << session->User();
+                    return session->User();
+                } else {
+                    greeterUser = session->User();
+                }
+            }
         }
+
+        if (!greeterUser.isEmpty()) {
+            qDebug() << "[DisplayManager] findUserByVt selected greeter session vtnr="
+                     << vtnr << " user=" << greeterUser;
+            return greeterUser;
+        }
+
+        qWarning() << "[DisplayManager] findUserByVt found no session for vtnr=" << vtnr;
         return QString();
     }
 


### PR DESCRIPTION
pms: BUG-349759
log: vt user lookup to prefer real user sessions over greeter entries


 findUserByVt() 的作用，是把当前活动 VT 反查成“这个 VT 上应该对应谁”。                                                
 原来的问题是，同一个 VT 上可能同时存在两类会话记录：                                                   
 - dde 的 greeter 占位会话                      

 - 用户真实登录后的会话，比如 uos   

                                             
 如果代码只是按 VTNr 先找到第一条记录就返回，就可能先返回 dde。这样在 VT 切换回图形界面时，后端会误以为当前应该激活 greeter，而不是用户会话，最后就会把 switchToUser("dde") 发出去，导致 greeter                     

 状态和真实用户状态错位。 

                                                              
 这个提交的原理就是两步：                                                        
 1. 同一个 VT 上，先找真实用户会话，跳过 dde    

 2. 如果没有真实用户会话，再退回到 dde


同一个 VT 上残留了多个 session 记录，而代码错误地把 greeter session 当成了当前用户 session。