### PR TITLE
fix(session): avoid tty control in Treeland

### DIFF
--- a/src/daemon/UserSession.cpp
+++ b/src/daemon/UserSession.cpp
@@ -132,12 +132,19 @@ namespace DDM {
     void UserSession::childModifier() {
         Auth *auth = qobject_cast<Auth *>(parent());
 
-        // When the display server is part of the session, we leak the VT into
-        // the session as stdin so that it stays open without races
+        // When the display server is part of the session, leak the VT into
+        // the session as stdin so that it stays open without races. Treeland
+        // single-mode sessions run under an already active compositor, so they
+        // must not take the VT as their controlling terminal.
         if (auth->type != Display::X11) {
-            // open VT and get the fd
-            QString ttyString = TtyUtils::path(auth->tty);
-            int vtFd = ::open(qPrintable(ttyString), O_RDWR | O_NOCTTY);
+            QString ttyString;
+            int vtFd = -1;
+
+            if (auth->type != Display::Treeland) {
+                // open VT and get the fd
+                ttyString = TtyUtils::path(auth->tty);
+                vtFd = ::open(qPrintable(ttyString), O_RDWR | O_NOCTTY);
+            }
 
             // when this is true we'll take control of the tty
             bool takeControl = false;


### PR DESCRIPTION
• 问题现象：

  Treeland single-mode 下，快速在 greeter 输入密码进入 session 时，dde-session 会在启动后一两秒退出，ddm 日志显示 session crash。慢一点输入密码时不容易复现。

  原因：

  原逻辑把所有非 X11 session 都当成需要接管 VT 的会话处理，会让 dde-session 打开 /dev/tty2 并通过 TIOCSCTTY 成为该 VT 的控制终端 leader。

  但 Treeland single-mode 下，真正持有显示服务端能力的是已经运行的 Treeland compositor，dde-session 只是用户会话进程，不应该接管 VT。快速登录时，dde-session 过早成为 /dev/tty2 的控制终端 leader，后续 Treeland / dde-seatd 完成 VT 切换时触发 tty hangup，内
  核向 dde-session 发送 SIGHUP，ddm 因此看到 session crash。

  解法：

  在 UserSession::childModifier() 中区分 Treeland single-mode 和普通 Wayland：

  - 普通 Wayland session 仍保持原逻辑，继续接管 VT。
  - Treeland single-mode session 不再打开 VT，也不再成为控制终端 leader，stdin 改为 /dev/null。

  修复后，dde-session 仍通过 XDG_VTNR=2 归属用户 VT，但进程本身不再占有 /dev/tty2，因此不会再被 tty hangup 的 SIGHUP 杀掉。

1. Skip opening the VT for Treeland single-mode user sessions, because the running Treeland compositor already owns the display server side.
2. Keep the VT-as-stdin and TIOCSCTTY path only for non-X11 sessions that start their own display server, such as standalone Wayland sessions.
3. Fix a fast-login race where dde-session became the controlling tty leader of /dev/tty2 while Treeland and dde-seatd were still completing VT transition.
4. The visible symptom was that dde-session appeared to crash shortly after login, while the real reason was a kernel SIGHUP caused by tty hangup.

Log: Prevent Treeland single-mode dde-session from taking the VT as controlling tty.

fix(session): 避免 Treeland 接管 tty

1. Treeland single-mode 用户会话不再打开 VT，因为显示服务端已经由正在运行的 Treeland compositor 持有。
2. 仅保留自带显示服务端的非 X11 会话继续走 VT stdin 和 TIOCSCTTY 路径，例如独立 Wayland 会话。
3. 修复快速登录时 dde-session 成为 /dev/tty2 控制终端 leader，而 Treeland 和 dde-seatd 仍在完成 VT 切换导致的时序问题。
4. 表现现象是登录后一两秒 dde-session 看起来像 crash，实际原因是 tty hangup 触发了内核发送的 SIGHUP。

Log: 避免 Treeland single-mode 下 dde-session 将 VT 作为控制终端。

## Summary by Sourcery

Adjust session VT handling to avoid Treeland single-mode sessions becoming the controlling TTY leader when a compositor is already active.

Bug Fixes:
- Prevent Treeland single-mode user sessions from opening and taking control of the VT owned by the running compositor, avoiding kernel SIGHUP-induced session termination in fast-login scenarios.

Enhancements:
- Restrict VT-as-stdin and TIOCSCTTY behavior to non-X11 sessions that start their own display server, such as standalone Wayland sessions.