### PR TITLE
chore: bump version to 0.3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25.0)
 
 project(DDM
-    VERSION 0.3.5
+    VERSION 0.3.6
     LANGUAGES CXX C)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ddm (0.3.6) unstable; urgency=medium
+
+  * fix(session): avoid tty control in Treeland
+
+ -- rewine <luhongxu@deepin.org>  Fri, 12 Jun 2026 16:17:52 +0800
+
 ddm (0.3.5) unstable; urgency=medium
 
   * refactor(vt): route VT control through dde-seatd


### PR DESCRIPTION
Log: bump

## Summary by Sourcery

Bump the project version from 0.3.5 to 0.3.6 in the CMake configuration.