### PR TITLE
fix(treeland): activate session before unlocking

### DIFF
--- a/src/daemon/Display.cpp
+++ b/src/daemon/Display.cpp
@@ -488,11 +488,14 @@ namespace DDM {
                 OrgFreedesktopLogin1ManagerInterface manager(Logind::serviceName(),
                                                              Logind::managerPath(),
                                                              QDBusConnection::systemBus());
-                manager.UnlockSession(QString::number(auth->xdgSessionId));
-                if (auth->type == Treeland)
+                if (auth->type == Treeland) {
                     activateSession(user, auth->xdgSessionId);
-                else if (!daemonApp->seatdControl()->requestSwitchVt(auth->tty))
-                    qWarning() << "Failed to switch to session VT" << auth->tty << "for user" << user;
+                    manager.UnlockSession(QString::number(auth->xdgSessionId));
+                } else {
+                    manager.UnlockSession(QString::number(auth->xdgSessionId));
+                    if (!daemonApp->seatdControl()->requestSwitchVt(auth->tty))
+                        qWarning() << "Failed to switch to session VT" << auth->tty << "for user" << user;
+                }
                 qInfo() << "Successfully identified user" << user;
                 return;
             }


### PR DESCRIPTION
Treeland 解锁已有用户 session 时，原流程先调用UnlockSession(sessionId)， 再调用 activateSession(user, sessionId)。这会让 logind Unlock 信号有机 会先于 Treeland activation 到达，使 Treeland 仍按旧 active session判断 unlock 目标，并可能把目标 session 重新锁回去。

本次仅调整 Treeland session 的解锁顺序：先通知 Treeland 激活目标 user 再调用 logind UnlockSession(sessionId)。非 Treeland session 仍保持原来 的 unlock 后切 VT 流程不变，避免影响 X11/Wayland 其它路径
Log: Fix Treeland unlock ordering during user switch PMS: BUG-346587
Influence: Affects DDM Treeland user switching and unlock flow

## Summary by Sourcery

Bug Fixes:
- Prevent Treeland sessions from being relocked during user switching by ensuring activation happens before logind unlock.