### PR TITLE
fix(auth): release daemon descriptors in session child

### DIFF
--- a/src/daemon/Auth.cpp
+++ b/src/daemon/Auth.cpp
@@ -17,10 +17,52 @@
 #include <security/pam_appl.h>
 #include <signal.h>
 #include <unistd.h>
+#include <climits>
+#include <sys/syscall.h>
 #include <utmp.h>
 #include <utmpx.h>
 
 namespace DDM {
+
+#ifdef SYS_close_range
+    bool tryCloseInheritedWithCloseRange(int preservedFd)
+    {
+        const unsigned int first = STDERR_FILENO + 1;
+        const unsigned int last  = UINT_MAX;
+
+        // No preserved FD in range: just close everything
+        if (preservedFd < 0 || static_cast<unsigned int>(preservedFd) < first)
+            return syscall(SYS_close_range, first, last, 0) == 0;
+
+        const unsigned int uPreservedFd = static_cast<unsigned int>(preservedFd);
+
+        // Close [first, preservedFd - 1]
+        if (uPreservedFd > first) {
+            if (syscall(SYS_close_range, first, uPreservedFd - 1, 0) == -1)
+                return false;
+        }
+
+        // Close [preservedFd + 1, last]
+        if (uPreservedFd < last) {
+            if (syscall(SYS_close_range, uPreservedFd + 1, last, 0) == -1)
+                return false;
+        }
+        return true;
+    }
+#endif
+
+    void closeInheritedFileDescriptors(int preservedFd)
+    {
+#ifdef SYS_close_range
+        if (tryCloseInheritedWithCloseRange(preservedFd))
+            return;
+#endif
+        const long maxFd = sysconf(_SC_OPEN_MAX);
+        for (int fd = STDERR_FILENO + 1; fd < maxFd; ++fd) {
+            if (fd != preservedFd)
+                close(fd);
+        }
+    }
 
     ///////////////////////////
     // utmp helper functions //
@@ -255,6 +297,10 @@ namespace DDM {
             // Delete old signal handlers, in order to close old fds
             // which are shared with the parent process.
             delete daemonApp->signalHandler();
+            // The session leader must not keep daemon-owned sockets alive.
+            // In particular, an inherited system bus fd would retain DDM's
+            // well-known names after the daemon exits.
+            closeInheritedFileDescriptors(pipefd[1]);
 
             // Restore default SIGINT and SIGTERM handlers. We need
             // the signal hander to terminate ourself, since we're


### PR DESCRIPTION
Close inherited daemon file descriptors in the forked session leader so old D-Bus connections cannot retain the display manager service names. Fail fast when D-Bus registration is unavailable and restore the original service start limit.

Log: DDM 通过 fork 创建 session leader 时，子进程若继承 system D-Bus fd，旧 DDM 主进程退出后仍可能保留 org.deepin.DisplayManager 服务名，阻 止新 DDM 注册。session child 仅保留标准流和与父进程通信的 pipe，并关闭
其余 daemon fd；DDM 注册 D-Bus 服务或对象失败时立即退出，避免 systemd
显示 active 而 D-Bus 实际不可用。该修复不处理 systemd start-limit-hit； DDM 被限流停止时必须 reset-failed 后重新启动。
PMS:
Influence: Affects session startup and DDM D-Bus ownership across daemon restarts.

fork之后 父子进程都会拥有  system dbus 的socket fd， 父进程会自己关闭，但是子进程也引用了同样的socket fd 。导致 下次重启的ddm服务无法注册新的 d-bus

  1. D-Bus fd 的所有者是 Qt D-Bus 模块内部的 QDBusConnection / connection cache；                                                                                                                                    
  2. SignalHandler 不拥有它，delete daemonApp->signalHandler() 不会关闭它；  

## Summary by Sourcery

Prevent session leader processes from inheriting daemon-owned file descriptors that keep D-Bus connections alive after the daemon exits.

Bug Fixes:
- Ensure session child closes inherited daemon sockets so old system D-Bus connections cannot retain the display manager service name across restarts.

Enhancements:
- Introduce a helper to close all non-standard file descriptors while preserving the parent communication pipe in forked session leaders.