### PR TITLE
chore: bump version to 0.3.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25.0)
 
 project(DDM
-    VERSION 0.3.6
+    VERSION 0.3.7
     LANGUAGES CXX C)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ddm (0.3.7) unstable; urgency=medium
+
+  * fix(auth): release daemon descriptors in session child
+  * chore: prioritize ddm and drop treeland override
+
+ -- rewine <luhongxu@deepin.org>  Fri, 17 Jul 2026 11:26:05 +0800
+
 ddm (0.3.6) unstable; urgency=medium
 
   * fix(session): avoid tty control in Treeland


### PR DESCRIPTION
Log: new tag

## Summary by Sourcery

Bump the project version from 0.3.6 to 0.3.7 in the CMake configuration and align packaging metadata accordingly.

Build:
- Update CMake project version to 0.3.7 for the DDM project.

Chores:
- Refresh Debian packaging changelog entry for the new 0.3.7 release tag.